### PR TITLE
feat : 닉네임 설정 일부 구현 [#11]

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,9 +37,26 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser(process.env.COOKIE_SECRET));
 app.use(sessionMiddleware);
 
+
+app.use((req, res, next) => {
+
+  //세션의 이름값이 비어있을때
+  if(!req.session.name)
+  {
+    req.session.name=`test`+(Math.random()*10);
+    console.log('새로운 유저의 이름 : '+req.session.name);
+  }
+  else //세션에 이미 이름이 있을때
+  {
+    console.log('기존 유저의 이름 : '+req.session.name);
+  }
+  next();
+});
+
 app.use('/', indexRouter);
 
 app.use((req, res, next) => {
+
   const error =  new Error(`${req.method} ${req.url} 라우터가 없습니다.`);
   error.status = 404;
   next(error);
@@ -51,6 +68,8 @@ app.use((err, req, res, next) => {
   res.status(err.status || 500);
   res.render('error');
 });
+
+
 
 const server = app.listen(app.get('port'), () => {
   console.log(app.get('port'), '번 포트에서 대기중');

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,7 +3,18 @@ const express = require('express');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
-    res.render('main');
+    if(!req.session.name)
+    {
+        res.render('main');
+    }
+    else
+    {
+        res.redirect('/lobby');
+    }
 });
+
+router.get('/lobby', async(req, res, next) => {
+    res.render('lobby', { title: '로비' });
+  });
 
 module.exports = router;

--- a/socket.js
+++ b/socket.js
@@ -1,13 +1,37 @@
 const SocketIO = require('socket.io');
+const axios = require('axios');
 
 module.exports = (server, app, sessionMiddleware) => {
   const io = SocketIO(server, { path: '/socket.io' });
   app.set('io', io);
   const room = io.of('/room');
   const chat = io.of('/chat');
+  const main=io.of('/');
+  const lobby = io.of('/lobby');
 
   io.use((socket, next) => {
     //cookieParser(process.env.COOKIE_SECRET)(socket.request, socket.request.res, next);
     sessionMiddleware(socket.request, socket.request.res, next);
   });
+
+  io.on('connection', (socket)=>
+  {
+    console.log(req.session.name+'님이 네임스페이스 접속');
+  })
+
+  main.on('connection', (socket) =>
+  {
+    console.log(req.session.name+'님이 main 네임스페이스 접속');
+    socket.on('disconnect', () => {
+      console.log('main 네임스페이스 접속 해제');
+    });
+  });
+
+  lobby.on('connection', (socket) =>
+  {
+    console.log(req.session.name+'님이 lobby 네임스페이스 접속');
+    socket.on('disconnect', () => {
+      console.log('lobby 네임스페이스 접속 해제');
+    });
+  })
 }

--- a/views/lobby.html
+++ b/views/lobby.html
@@ -1,14 +1,13 @@
 {% extends 'layout.html' %}
 {% block content %}
-<h1>메인</h1>
+<h1>로비</h1>
 {% endblock %}
 <script>
     const socket = io.connect
-    ('http://localhost:3000', { 
-        // main네임스페이스 connection 이벤트 발생시키기
+    ('http://localhost:3000/lobby', { 
+        // lobby네임스페이스 connection 이벤트 발생시키기
     path: '/socket.io',
-    });
-    socket.emit('setname', 'test1');
+  });
 </script>
 {% block script %}
 {% endblock %}


### PR DESCRIPTION
- 메인 접속 시 session에 닉네임 정보가 있으면 lobby로 redirect
- 닉네임 설정 기능 구현하기 전, 임시로 닉네임을 test{난수} 로 자동 생성 후 lobby로 redirect하도록 구현해둠.
- namespace접속 관련 오류 발생. 수정 예정