### PR TITLE
feat : 싱글방 문제세트를 싱글로 전송 [#27]

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -28,16 +28,12 @@ router.get('/lobby', async (req,res,next) => {
 });
 
 router.get('/single', async (req,res,next) => {
-	res.render('single')
+	res.render('single');
 });
 
 router.get('/crawl', async (req, res, next) => {
     await Champion.create(crawlData);
     res.redirect('/');
 });
-
-router.get('/single', async (req,res,next) => {
-	res.render('single')
-})
 
 module.exports = router;

--- a/socket.js
+++ b/socket.js
@@ -31,7 +31,7 @@ module.exports = (server, app, sessionMiddleware) => {
 
     function sendQuizSet()
     {
-      var quizSet=[];//넘길 퀴즈셋 초기화
+      var quizSet1=[];//넘길 퀴즈셋 초기화
       var randomtestIndex=0;
 
       Chams.find({name:champions[randomtestIndex]}, function(err,docs)
@@ -39,23 +39,51 @@ module.exports = (server, app, sessionMiddleware) => {
         var randomIndex=[0,1,2,3];
         for(var i=0;i<4;i++)
         {
-          quizSet[i]=docs[randomIndex[i]]
+          quizSet1[i]=docs[randomIndex[i]]
         }
-        console.log(quizSet);
-        return quizSet;
+        //console.log(quizSet);
+        return quizSet1[0];
       });
     }
 
     var quizSet=[];
     quizSet=sendQuizSet();
-    socket.to(singleRoomId).emit('get', quizSet);
+    socket.emit('get', quizSet);
 
     socket.on('make', ()=>//make 요청이 오면,
     {
       var quizSet=[];
-      quizSet=sendQuizSet();
-      socket.to(singleRoomId).emit('get', quizSet);
+      var quizSet1=[];//넘길 퀴즈셋 초기화
+      var randomtestIndex=0;
+
+      Chams.find({name:champions[randomtestIndex]}, function(err,docs)
+      {
+        var randomIndex=[0,1,2,3];
+        for(var i=0;i<4;i++)
+        {
+          quizSet1[i]=docs[randomIndex[i]]
+        }
+        socket.emit('get', quizSet1);
+      });
+      // quizSet=sendQuizSet();
+      // console.log(quizSet);
+      
       //해당 유저의 singleRoom에 get 으로 퀴즈셋 전송
+    });
+
+    //
+
+    socket.on('correct', (answer,score,time)=>
+    {
+      //answer은 보낸 문제셋의 이름값과 사용자가 보낸 정답지 배열
+      //score은 현재 사용자의 점수
+      if(answer[0]==answer[1])
+      {
+        score+=1;
+        var quizSet=[];
+        quizSet=sendQuizSet();
+        socket.to(singleRoomId).emit('get', {quizSet, score})
+      }
     });
     
     socket.on('disconnect',()=>{

--- a/socket.js
+++ b/socket.js
@@ -1,4 +1,8 @@
 const SocketIO = require('socket.io');
+const connect=require('./schemas/index');
+const Chams=require('./schemas/champion');
+//Chams는 이제 모델을 담고있다.
+//mongoose.model('Champion', championSchema);
 
 module.exports = (server, app, sessionMiddleware) => {
   const io = SocketIO(server, { path: '/socket.io' });
@@ -22,6 +26,34 @@ module.exports = (server, app, sessionMiddleware) => {
     console.log(singleRoomId);
     socket.join(singleRoomId);
 
+    const champions = ["amumu", "janna", "katarina", "garen", "lux", "gnar", "zed", "annie", "monkeyking", "akali", "camille", "drmundo", "kennen"];
+    //받아올 챔 이름들
+
+    function sendQuizSet()
+    {
+      var quizSet=[];//넘길 퀴즈셋 초기화
+      var randomtestIndex=0;
+
+      Chams.find({name:champions[randomtestIndex]}, function(err,docs)
+      {
+        var randomIndex=[0,1,2,3];
+        for(var i=0;i<4;i++)
+        {
+          quizSet[i]=docs[randomIndex[i]]
+        }
+        console.log(quizSet);
+        return quizSet;
+      });
+    }
+
+    socket.on('make', ()=>//make 요청이 오면,
+    {
+      var quizSet=[];
+      quizSet=sendQuizSet();
+      socket.to(singleRoomId).emit('get', quizSet);
+      //해당 유저의 singleRoom에 get 으로 퀴즈셋 전송
+    });
+    
     socket.on('disconnect',()=>{
       socket.leave(singleRoomId);
     });

--- a/socket.js
+++ b/socket.js
@@ -46,6 +46,10 @@ module.exports = (server, app, sessionMiddleware) => {
       });
     }
 
+    var quizSet=[];
+    quizSet=sendQuizSet();
+    socket.to(singleRoomId).emit('get', quizSet);
+
     socket.on('make', ()=>//make 요청이 오면,
     {
       var quizSet=[];


### PR DESCRIPTION
- socket.js 에서 Chams로 크롤링된 모델을 담고,
- make로 서버에 문제셋 요청을 보내면 챔피언들 중 랜덤으로 하나를 골라 해당 챔피언의 content 4개를 quizSet 배열에 담은 후 get 통로를 이용해 해당 문제셋 전송 요청을 날림.
- 추후 기능이 모두 구현될 쯤에 randomtestIndex, randomIndex엔 랜덤 함수를 이용해 난수를 집어넣고 랜덤하게 선택 후 보낼 예정

Resolves #27